### PR TITLE
Fix navigate to contacts list when user is already signed-in

### DIFF
--- a/lib/blocs/app_bloc.dart
+++ b/lib/blocs/app_bloc.dart
@@ -43,8 +43,8 @@ class AppBloc {
     // current view
 
     final Stream<CurrentView> currentView = Rx.merge([
-      currentViewBasedOnAuthStatus,
       viewsBloc.currentView,
+      currentViewBasedOnAuthStatus,
     ]);
 
     // isLoading


### PR DESCRIPTION
for the first time when user creates an account, the app navigates to contact list, but when you hot reload the app or run the app for second time, login page is displayed and by tapping on login button, app doesn't navigate to contacts list. because firebase `authStausChange` only called once user state changes. and because user is already signed-in, by tapping on login button state doesn't get updated.

by swapping the `currentViewBasedOnAuthStatus` and `viewsBloc.currentView`, the new stream created by merge, the last event will be CurrentView.contactsList not CurrentView.login. merged stream always emits the right value.
```
final Stream<CurrentView> currentView = Rx.merge([
      viewsBloc.currentView,
      currentViewBasedOnAuthStatus,
    ]);
```